### PR TITLE
Trying to fix cloudconnexa_user resource

### DIFF
--- a/cloudconnexa/users.go
+++ b/cloudconnexa/users.go
@@ -86,7 +86,7 @@ func (c *UsersService) List(username string, role string) (*User, error) {
 
 func (c *UsersService) Get(userId string) (*User, error) {
 	pageSize := 10
-	page := 1
+	page := 0
 
 	for {
 		response, err := c.GetByPage(page, pageSize)


### PR DESCRIPTION
I have created resource "cloudconnexa_user" via code below:

```
terraform {
  required_version = ">= 1.6.6"
  required_providers {
    cloudconnexa = {
      source  = "OpenVPN/cloudconnexa"
      version = "0.1.0"
    }
  }
}

variable "company_name" {
  type        = string
  description = "Company name in CloudConnexa"
  default     = "xxx"
}

provider "cloudconnexa" {
  base_url = "https://${var.company_name}.api.openvpn.com"
}

resource "cloudconnexa_user" "this" {
  username   = "test"
  email      = "xxx@gmail.com"
  first_name = "AAAAA"
  last_name  = "BBBBB"
}
```

When i run "terraform apply" user was created, i was able to verify and confirm this in UI.

But when i run "terraform plan" i've got next error:
```
cloudconnexa_user.this: Refreshing state... [id=test@xxx]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: user with ID test@xxx not found
│ 
│   with cloudconnexa_user.this,
│   on test.tf line 1, in resource "cloudconnexa_user" "this":
│    1: resource "cloudconnexa_user" "this" {
│ 
```

When i've looked into Swagger (section "GET   /api/beta/users/page     get existing users" Request URL to get users is:
https://xxx.api.openvpn.com/api/beta/users/page?page=0&size=10

