### PR TITLE
Adjust CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @arslanbekov
+* @OpenVPN/cloudconnexa-terraform-project-admins


### PR DESCRIPTION
This PR is intended to make CODEOWNERS file to be same as for https://github.com/OpenVPN/terraform-provider-cloudconnexa/blob/main/.github/CODEOWNERS