### PR TITLE
Add "description" for Connector struct

### DIFF
--- a/cloudconnexa/connectors.go
+++ b/cloudconnexa/connectors.go
@@ -10,6 +10,7 @@ import (
 type ConnectionStatus string
 
 type Connector struct {
+	Description      string           `json:"description"`
 	Id               string           `json:"id,omitempty"`
 	Name             string           `json:"name"`
 	NetworkItemId    string           `json:"networkItemId"`

--- a/cloudconnexa/connectors.go
+++ b/cloudconnexa/connectors.go
@@ -10,7 +10,7 @@ import (
 type ConnectionStatus string
 
 type Connector struct {
-	Description      string           `json:"description"`
+	Description      string           `json:"description,omitempty"`
 	Id               string           `json:"id,omitempty"`
 	Name             string           `json:"name"`
 	NetworkItemId    string           `json:"networkItemId"`


### PR DESCRIPTION
This "Connector" struct is used with both cloudconnexa_connector and cloudconnexa_network. Main purpose of this PR to fix this issue: "Perpetual drift on description for default_connector in cloudconnexa_network resource" (https://github.com/OpenVPN/cloudconnexa-go-client/issues/14)