### PR TITLE
Add VPN Regions support with List, GetByPage, and GetByID methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ user := cloudconnexa.User{
 createdUser, err := client.Users.Create(user)
 ```
 
+### Listing VPN Regions
+
+```go
+// List all VPN regions
+regions, err := client.VPNRegions.List()
+if err != nil {
+    log.Fatalf("error getting VPN regions: %v", err)
+}
+
+// Get specific region by ID
+region, err := client.VPNRegions.GetByID("region-id")
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.

--- a/cloudconnexa/vpn_regions.go
+++ b/cloudconnexa/vpn_regions.go
@@ -16,7 +16,61 @@ type VpnRegion struct {
 
 type VPNRegionsService service
 
-func (c *VPNRegionsService) GetVpnRegion(regionID string) (*VpnRegion, error) {
+type VPNRegionPageResponse struct {
+	Content          []VpnRegion `json:"content"`
+	NumberOfElements int         `json:"numberOfElements"`
+	Page             int         `json:"page"`
+	Size             int         `json:"size"`
+	Success          bool        `json:"success"`
+	TotalElements    int         `json:"totalElements"`
+	TotalPages       int         `json:"totalPages"`
+}
+
+// GetByPage retrieves a page of VPN regions
+func (c *VPNRegionsService) GetByPage(page int, pageSize int) (VPNRegionPageResponse, error) {
+	endpoint := fmt.Sprintf("%s/vpn-regions?page=%d&size=%d", c.client.GetV1Url(), page, pageSize)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return VPNRegionPageResponse{}, err
+	}
+
+	body, err := c.client.DoRequest(req)
+	if err != nil {
+		return VPNRegionPageResponse{}, err
+	}
+
+	var response VPNRegionPageResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return VPNRegionPageResponse{}, err
+	}
+	return response, nil
+}
+
+// List retrieves all VPN regions
+func (c *VPNRegionsService) List() ([]VpnRegion, error) {
+	var allRegions []VpnRegion
+	pageSize := 10
+	page := 0
+
+	for {
+		response, err := c.GetByPage(page, pageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		allRegions = append(allRegions, response.Content...)
+
+		if page >= response.TotalPages {
+			break
+		}
+		page++
+	}
+	return allRegions, nil
+}
+
+// GetByID retrieves a specific VPN region by ID
+func (c *VPNRegionsService) GetByID(regionID string) (*VpnRegion, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/regions", c.client.GetV1Url()), nil)
 	if err != nil {
 		return nil, err

--- a/cloudconnexa/vpn_regions.go
+++ b/cloudconnexa/vpn_regions.go
@@ -16,57 +16,24 @@ type VpnRegion struct {
 
 type VPNRegionsService service
 
-type VPNRegionPageResponse struct {
-	Content          []VpnRegion `json:"content"`
-	NumberOfElements int         `json:"numberOfElements"`
-	Page             int         `json:"page"`
-	Size             int         `json:"size"`
-	Success          bool        `json:"success"`
-	TotalElements    int         `json:"totalElements"`
-	TotalPages       int         `json:"totalPages"`
-}
-
-// GetByPage retrieves a page of VPN regions
-func (c *VPNRegionsService) GetByPage(page int, pageSize int) (VPNRegionPageResponse, error) {
-	endpoint := fmt.Sprintf("%s/vpn-regions?page=%d&size=%d", c.client.GetV1Url(), page, pageSize)
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+// List retrieves all VPN regions
+func (c *VPNRegionsService) List() ([]VpnRegion, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/regions", c.client.GetV1Url()), nil)
 	if err != nil {
-		return VPNRegionPageResponse{}, err
+		return nil, err
 	}
 
 	body, err := c.client.DoRequest(req)
 	if err != nil {
-		return VPNRegionPageResponse{}, err
+		return nil, err
 	}
 
-	var response VPNRegionPageResponse
-	err = json.Unmarshal(body, &response)
+	var regions []VpnRegion
+	err = json.Unmarshal(body, &regions)
 	if err != nil {
-		return VPNRegionPageResponse{}, err
+		return nil, err
 	}
-	return response, nil
-}
-
-// List retrieves all VPN regions
-func (c *VPNRegionsService) List() ([]VpnRegion, error) {
-	var allRegions []VpnRegion
-	pageSize := 10
-	page := 0
-
-	for {
-		response, err := c.GetByPage(page, pageSize)
-		if err != nil {
-			return nil, err
-		}
-
-		allRegions = append(allRegions, response.Content...)
-
-		if page >= response.TotalPages {
-			break
-		}
-		page++
-	}
-	return allRegions, nil
+	return regions, nil
 }
 
 // GetByID retrieves a specific VPN region by ID

--- a/cloudconnexa/vpn_regions_test.go
+++ b/cloudconnexa/vpn_regions_test.go
@@ -9,35 +9,121 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testVpnRegion = VpnRegion{
+	ID:         "test-region",
+	Country:    "Test Country",
+	Continent:  "Test Continent",
+	CountryISO: "TC",
+	RegionName: "Test Region",
+}
+
 func TestVPNRegionsService_GetByPage(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle auth token request
+		if r.URL.Path == "/api/v1/oauth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "test-token",
+			})
+			assert.NoError(t, err)
+			return
+		}
+
+		// Handle VPN regions request
 		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
 		assert.Equal(t, "page=0&size=10", r.URL.RawQuery)
 
 		response := VPNRegionPageResponse{
-			Content: []VpnRegion{
-				{
-					ID:         "test-region",
-					Country:    "Test Country",
-					Continent:  "Test Continent",
-					CountryISO: "TC",
-				},
-			},
+			Content:          []VpnRegion{testVpnRegion},
 			Success:          true,
 			NumberOfElements: 1,
 			TotalElements:    1,
 		}
 
-		json.NewEncoder(w).Encode(response)
+		err := json.NewEncoder(w).Encode(response)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
-	client, _ := NewClient(server.URL, "test", "test")
+	client, err := NewClient(server.URL, "test", "test")
+	assert.NoError(t, err)
 	response, err := client.VPNRegions.GetByPage(0, 10)
 
 	assert.NoError(t, err)
 	assert.True(t, response.Success)
 	assert.Equal(t, 1, len(response.Content))
-	assert.Equal(t, "test-region", response.Content[0].ID)
+	assert.Equal(t, testVpnRegion.ID, response.Content[0].ID)
+}
+
+func TestVPNRegionsService_List(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle auth token request
+		if r.URL.Path == "/api/v1/oauth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "test-token",
+			})
+			assert.NoError(t, err)
+			return
+		}
+
+		// Handle VPN regions request
+		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
+
+		response := VPNRegionPageResponse{
+			Content:          []VpnRegion{testVpnRegion},
+			Success:          true,
+			NumberOfElements: 1,
+			TotalElements:    1,
+			TotalPages:       1,
+		}
+
+		err := json.NewEncoder(w).Encode(response)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "test", "test")
+	assert.NoError(t, err)
+	regions, err := client.VPNRegions.List()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(regions))
+	assert.Equal(t, testVpnRegion.ID, regions[0].ID)
+}
+
+func TestVPNRegionsService_GetByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle auth token request
+		if r.URL.Path == "/api/v1/oauth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "test-token",
+			})
+			assert.NoError(t, err)
+			return
+		}
+
+		// Handle VPN regions request
+		assert.Equal(t, "/api/v1/regions", r.URL.Path)
+
+		err := json.NewEncoder(w).Encode([]VpnRegion{testVpnRegion})
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "test", "test")
+	assert.NoError(t, err)
+
+	// Test existing region
+	region, err := client.VPNRegions.GetByID(testVpnRegion.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, region)
+	assert.Equal(t, testVpnRegion.ID, region.ID)
+
+	// Test non-existent region
+	region, err = client.VPNRegions.GetByID("non-existent")
+	assert.NoError(t, err)
+	assert.Nil(t, region)
 }

--- a/cloudconnexa/vpn_regions_test.go
+++ b/cloudconnexa/vpn_regions_test.go
@@ -17,47 +17,7 @@ var testVpnRegion = VpnRegion{
 	RegionName: "Test Region",
 }
 
-func TestVPNRegionsService_GetByPage(t *testing.T) {
-	// Create test server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Handle auth token request
-		if r.URL.Path == "/api/v1/oauth/token" {
-			w.Header().Set("Content-Type", "application/json")
-			err := json.NewEncoder(w).Encode(map[string]string{
-				"access_token": "test-token",
-			})
-			assert.NoError(t, err)
-			return
-		}
-
-		// Handle VPN regions request
-		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
-		assert.Equal(t, "page=0&size=10", r.URL.RawQuery)
-
-		response := VPNRegionPageResponse{
-			Content:          []VpnRegion{testVpnRegion},
-			Success:          true,
-			NumberOfElements: 1,
-			TotalElements:    1,
-		}
-
-		err := json.NewEncoder(w).Encode(response)
-		assert.NoError(t, err)
-	}))
-	defer server.Close()
-
-	client, err := NewClient(server.URL, "test", "test")
-	assert.NoError(t, err)
-	response, err := client.VPNRegions.GetByPage(0, 10)
-
-	assert.NoError(t, err)
-	assert.True(t, response.Success)
-	assert.Equal(t, 1, len(response.Content))
-	assert.Equal(t, testVpnRegion.ID, response.Content[0].ID)
-}
-
 func TestVPNRegionsService_List(t *testing.T) {
-	pageCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle auth token request
 		if r.URL.Path == "/api/v1/oauth/token" {
@@ -70,19 +30,11 @@ func TestVPNRegionsService_List(t *testing.T) {
 		}
 
 		// Handle VPN regions request
-		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
-		pageCount++
+		assert.Equal(t, "/api/v1/regions", r.URL.Path)
 
-		response := VPNRegionPageResponse{
-			Content:          []VpnRegion{testVpnRegion},
-			Success:          true,
-			NumberOfElements: 1,
-			TotalElements:    1,
-			TotalPages:       0,
-			Page:             0,
-		}
+		regions := []VpnRegion{testVpnRegion}
 
-		err := json.NewEncoder(w).Encode(response)
+		err := json.NewEncoder(w).Encode(regions)
 		assert.NoError(t, err)
 	}))
 	defer server.Close()
@@ -92,7 +44,6 @@ func TestVPNRegionsService_List(t *testing.T) {
 	regions, err := client.VPNRegions.List()
 
 	assert.NoError(t, err)
-	assert.Equal(t, 1, pageCount, "Expected only one page request")
 	assert.Equal(t, 1, len(regions))
 	assert.Equal(t, testVpnRegion.ID, regions[0].ID)
 }

--- a/cloudconnexa/vpn_regions_test.go
+++ b/cloudconnexa/vpn_regions_test.go
@@ -1,0 +1,43 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVPNRegionsService_GetByPage(t *testing.T) {
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
+		assert.Equal(t, "page=0&size=10", r.URL.RawQuery)
+
+		response := VPNRegionPageResponse{
+			Content: []VpnRegion{
+				{
+					ID:         "test-region",
+					Country:    "Test Country",
+					Continent:  "Test Continent",
+					CountryISO: "TC",
+				},
+			},
+			Success:          true,
+			NumberOfElements: 1,
+			TotalElements:    1,
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "test", "test")
+	response, err := client.VPNRegions.GetByPage(0, 10)
+
+	assert.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, 1, len(response.Content))
+	assert.Equal(t, "test-region", response.Content[0].ID)
+}

--- a/cloudconnexa/vpn_regions_test.go
+++ b/cloudconnexa/vpn_regions_test.go
@@ -57,6 +57,7 @@ func TestVPNRegionsService_GetByPage(t *testing.T) {
 }
 
 func TestVPNRegionsService_List(t *testing.T) {
+	pageCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle auth token request
 		if r.URL.Path == "/api/v1/oauth/token" {
@@ -70,13 +71,15 @@ func TestVPNRegionsService_List(t *testing.T) {
 
 		// Handle VPN regions request
 		assert.Equal(t, "/api/v1/vpn-regions", r.URL.Path)
+		pageCount++
 
 		response := VPNRegionPageResponse{
 			Content:          []VpnRegion{testVpnRegion},
 			Success:          true,
 			NumberOfElements: 1,
 			TotalElements:    1,
-			TotalPages:       1,
+			TotalPages:       0,
+			Page:             0,
 		}
 
 		err := json.NewEncoder(w).Encode(response)
@@ -89,6 +92,7 @@ func TestVPNRegionsService_List(t *testing.T) {
 	regions, err := client.VPNRegions.List()
 
 	assert.NoError(t, err)
+	assert.Equal(t, 1, pageCount, "Expected only one page request")
 	assert.Equal(t, 1, len(regions))
 	assert.Equal(t, testVpnRegion.ID, regions[0].ID)
 }

--- a/e2e/client_test.go
+++ b/e2e/client_test.go
@@ -58,18 +58,11 @@ func TestListConnectors(t *testing.T) {
 func TestVPNRegions(t *testing.T) {
 	c := setUpClient(t)
 
-	// Test GetByPage
-	response, err := c.VPNRegions.GetByPage(0, 10)
-	require.NoError(t, err)
-	require.NotNil(t, response)
-	require.True(t, response.Success)
-	fmt.Printf("found %d VPN regions on first page\n", len(response.Content))
-
 	// Test List
 	regions, err := c.VPNRegions.List()
 	require.NoError(t, err)
 	require.NotNil(t, regions)
-	fmt.Printf("found total %d VPN regions\n", len(regions))
+	fmt.Printf("found %d VPN regions\n", len(regions))
 
 	// If regions exist, test GetByID
 	if len(regions) > 0 {

--- a/e2e/client_test.go
+++ b/e2e/client_test.go
@@ -55,6 +55,41 @@ func TestListConnectors(t *testing.T) {
 	fmt.Printf("found %d connectors\n", len(response.Content))
 }
 
+func TestVPNRegions(t *testing.T) {
+	c := setUpClient(t)
+
+	// Test GetByPage
+	response, err := c.VPNRegions.GetByPage(0, 10)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.True(t, response.Success)
+	fmt.Printf("found %d VPN regions on first page\n", len(response.Content))
+
+	// Test List
+	regions, err := c.VPNRegions.List()
+	require.NoError(t, err)
+	require.NotNil(t, regions)
+	fmt.Printf("found total %d VPN regions\n", len(regions))
+
+	// If regions exist, test GetByID
+	if len(regions) > 0 {
+		region := regions[0]
+		foundRegion, err := c.VPNRegions.GetByID(region.ID)
+		require.NoError(t, err)
+		require.NotNil(t, foundRegion)
+		require.Equal(t, region.ID, foundRegion.ID)
+		require.Equal(t, region.Country, foundRegion.Country)
+		require.Equal(t, region.Continent, foundRegion.Continent)
+		fmt.Printf("successfully found region %s in %s, %s\n",
+			foundRegion.ID, foundRegion.Country, foundRegion.Continent)
+	}
+
+	// Test GetByID with non-existent ID
+	nonExistentRegion, err := c.VPNRegions.GetByID("non-existent-id")
+	require.NoError(t, err)
+	require.Nil(t, nonExistentRegion)
+}
+
 func TestCreateNetwork(t *testing.T) {
 	c := setUpClient(t)
 	timestamp := time.Now().Unix()


### PR DESCRIPTION
## Description

- Implement VPN Regions functionality in `cloudconnexa/vpn_regions.go`
- Add `List()` method to retrieve all VPN regions
- Add `GetByID()` method to retrieve a specific VPN region
- Update README.md with VPN Regions usage example
- Add comprehensive end-to-end tests for VPN Regions methods

Fixes [#16 (issue)](https://github.com/OpenVPN/cloudconnexa-go-client/issues/16)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
