### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/1](https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since this is a release workflow, it likely requires `contents: write` to create releases and manage repository contents. We will also include `contents: read` for basic repository access. The `permissions` block will be added at the workflow level to apply to all jobs, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
