### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/3](https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs linting and formatting tasks, it requires minimal permissions. The `contents: read` permission is sufficient for this workflow, as it allows the workflow to read repository contents without granting unnecessary write access. The `permissions` block should be added at the root level of the workflow file to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
