### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/5](https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the minimal permissions required are likely `contents: read`. This ensures that the workflow can interact with the repository contents without granting unnecessary `write` permissions.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
