### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/2](https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, it primarily needs `contents: read` to check out the repository and possibly `id-token: write` if OpenID Connect tokens are required for authentication with external services. Since the workflow uploads coverage data to Codecov, no additional permissions are needed for repository operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
