### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/6](https://github.com/OpenVPN/cloudconnexa-go-client/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations (checkout, caching, setting up Go, building, and testing), the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
