### PR TITLE
Feature/support 1.1.0 api

### DIFF
--- a/cloudconnexa/cloudconnexa.go
+++ b/cloudconnexa/cloudconnexa.go
@@ -45,6 +45,8 @@ type Client struct {
 	LocationContexts    *LocationContextsService
 	AccessGroups        *AccessGroupsService
 	Settings            *SettingsService
+	Sessions            *SessionsService
+	Devices             *DevicesService
 }
 
 type service struct {
@@ -136,6 +138,8 @@ func NewClient(baseURL, clientID, clientSecret string) (*Client, error) {
 	c.LocationContexts = (*LocationContextsService)(&c.common)
 	c.AccessGroups = (*AccessGroupsService)(&c.common)
 	c.Settings = (*SettingsService)(&c.common)
+	c.Sessions = (*SessionsService)(&c.common)
+	c.Devices = (*DevicesService)(&c.common)
 	return c, nil
 }
 

--- a/cloudconnexa/devices.go
+++ b/cloudconnexa/devices.go
@@ -1,0 +1,299 @@
+package cloudconnexa
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// DeviceStatus represents the possible statuses of a device.
+type DeviceStatus string
+
+const (
+	// DeviceStatusActive represents an active device.
+	DeviceStatusActive DeviceStatus = "ACTIVE"
+	// DeviceStatusInactive represents an inactive device.
+	DeviceStatusInactive DeviceStatus = "INACTIVE"
+	// DeviceStatusBlocked represents a blocked device.
+	DeviceStatusBlocked DeviceStatus = "BLOCKED"
+	// DeviceStatusPending represents a pending device.
+	DeviceStatusPending DeviceStatus = "PENDING"
+)
+
+// DeviceType represents the type of device.
+type DeviceType string
+
+const (
+	// DeviceTypeClient represents a client device.
+	DeviceTypeClient DeviceType = "CLIENT"
+	// DeviceTypeConnector represents a connector device.
+	DeviceTypeConnector DeviceType = "CONNECTOR"
+)
+
+// DeviceDetail represents a detailed device in CloudConnexa.
+type DeviceDetail struct {
+	ID                 string                 `json:"id"`
+	Name               string                 `json:"name"`
+	Description        string                 `json:"description,omitempty"`
+	UserID             string                 `json:"userId"`
+	Status             string                 `json:"status"`
+	Type               string                 `json:"type"`
+	Platform           string                 `json:"platform,omitempty"`
+	Version            string                 `json:"version,omitempty"`
+	LastSeen           *time.Time             `json:"lastSeen,omitempty"`
+	CreatedAt          time.Time              `json:"createdAt"`
+	UpdatedAt          time.Time              `json:"updatedAt"`
+	IPv4Address        string                 `json:"ipv4Address,omitempty"`
+	IPv6Address        string                 `json:"ipv6Address,omitempty"`
+	PublicKey          string                 `json:"publicKey,omitempty"`
+	Fingerprint        string                 `json:"fingerprint,omitempty"`
+	SerialNumber       string                 `json:"serialNumber,omitempty"`
+	MACAddress         string                 `json:"macAddress,omitempty"`
+	Hostname           string                 `json:"hostname,omitempty"`
+	OperatingSystem    string                 `json:"operatingSystem,omitempty"`
+	OSVersion          string                 `json:"osVersion,omitempty"`
+	ClientVersion      string                 `json:"clientVersion,omitempty"`
+	IsOnline           bool                   `json:"isOnline"`
+	LastConnectedAt    *time.Time             `json:"lastConnectedAt,omitempty"`
+	LastDisconnectedAt *time.Time             `json:"lastDisconnectedAt,omitempty"`
+	TotalBytesIn       int64                  `json:"totalBytesIn"`
+	TotalBytesOut      int64                  `json:"totalBytesOut"`
+	SessionCount       int                    `json:"sessionCount"`
+	Region             string                 `json:"region,omitempty"`
+	Gateway            string                 `json:"gateway,omitempty"`
+	UserGroupID        string                 `json:"userGroupId,omitempty"`
+	NetworkID          string                 `json:"networkId,omitempty"`
+	Tags               []string               `json:"tags,omitempty"`
+	Metadata           map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// DevicePageResponse represents a paginated response of devices.
+type DevicePageResponse struct {
+	Content          []DeviceDetail `json:"content"`
+	NumberOfElements int            `json:"numberOfElements"`
+	Page             int            `json:"page"`
+	Size             int            `json:"size"`
+	Success          bool           `json:"success"`
+	TotalElements    int            `json:"totalElements"`
+	TotalPages       int            `json:"totalPages"`
+}
+
+// DeviceListOptions represents the options for listing devices.
+type DeviceListOptions struct {
+	UserID string `json:"userId,omitempty"`
+	Page   int    `json:"page,omitempty"`
+	Size   int    `json:"size,omitempty"`
+}
+
+// DeviceUpdateRequest represents the request body for updating a device.
+type DeviceUpdateRequest struct {
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Status      string                 `json:"status,omitempty"`
+	Tags        []string               `json:"tags,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// DevicesService provides methods for managing devices.
+type DevicesService service
+
+// List retrieves a list of devices with optional filtering and pagination.
+func (d *DevicesService) List(options DeviceListOptions) (*DevicePageResponse, error) {
+	// Build query parameters
+	params := url.Values{}
+
+	if options.UserID != "" {
+		params.Set("userId", options.UserID)
+	}
+
+	if options.Page > 0 {
+		params.Set("page", strconv.Itoa(options.Page))
+	}
+
+	if options.Size > 0 {
+		// Validate size parameter (1-1000 according to API docs)
+		if options.Size < 1 || options.Size > 1000 {
+			return nil, fmt.Errorf("size must be between 1 and 1000, got %d", options.Size)
+		}
+		params.Set("size", strconv.Itoa(options.Size))
+	}
+
+	endpoint := fmt.Sprintf("%s/devices", d.client.GetV1Url())
+	if len(params) > 0 {
+		endpoint += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := d.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DevicePageResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// GetByPage retrieves devices using pagination.
+func (d *DevicesService) GetByPage(page int, pageSize int) (*DevicePageResponse, error) {
+	options := DeviceListOptions{
+		Page: page,
+		Size: pageSize,
+	}
+	return d.List(options)
+}
+
+// ListAll retrieves all devices by paginating through all available pages.
+func (d *DevicesService) ListAll() ([]DeviceDetail, error) {
+	var allDevices []DeviceDetail
+	page := 0
+	pageSize := 100 // Use maximum page size for efficiency
+
+	for {
+		response, err := d.GetByPage(page, pageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		allDevices = append(allDevices, response.Content...)
+
+		// If we've reached the last page, break
+		if page >= response.TotalPages-1 {
+			break
+		}
+		page++
+	}
+
+	return allDevices, nil
+}
+
+// GetByID retrieves a specific device by its ID.
+func (d *DevicesService) GetByID(deviceID string) (*DeviceDetail, error) {
+	endpoint := fmt.Sprintf("%s/devices/%s", d.client.GetV1Url(), deviceID)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := d.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var device DeviceDetail
+	err = json.Unmarshal(body, &device)
+	if err != nil {
+		return nil, err
+	}
+
+	return &device, nil
+}
+
+// Update updates an existing device by its ID.
+func (d *DevicesService) Update(deviceID string, updateRequest DeviceUpdateRequest) (*DeviceDetail, error) {
+	requestJSON, err := json.Marshal(updateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s/devices/%s", d.client.GetV1Url(), deviceID)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(requestJSON))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := d.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var device DeviceDetail
+	err = json.Unmarshal(body, &device)
+	if err != nil {
+		return nil, err
+	}
+
+	return &device, nil
+}
+
+// ListByUserID retrieves all devices for a specific user.
+func (d *DevicesService) ListByUserID(userID string) ([]DeviceDetail, error) {
+	var allDevices []DeviceDetail
+	page := 0
+	pageSize := 100
+
+	for {
+		options := DeviceListOptions{
+			UserID: userID,
+			Page:   page,
+			Size:   pageSize,
+		}
+
+		response, err := d.List(options)
+		if err != nil {
+			return nil, err
+		}
+
+		allDevices = append(allDevices, response.Content...)
+
+		// If we've reached the last page, break
+		if page >= response.TotalPages-1 {
+			break
+		}
+		page++
+	}
+
+	return allDevices, nil
+}
+
+// Block blocks a device by updating its status to BLOCKED.
+func (d *DevicesService) Block(deviceID string) (*DeviceDetail, error) {
+	updateRequest := DeviceUpdateRequest{
+		Status: string(DeviceStatusBlocked),
+	}
+	return d.Update(deviceID, updateRequest)
+}
+
+// Unblock unblocks a device by updating its status to ACTIVE.
+func (d *DevicesService) Unblock(deviceID string) (*DeviceDetail, error) {
+	updateRequest := DeviceUpdateRequest{
+		Status: string(DeviceStatusActive),
+	}
+	return d.Update(deviceID, updateRequest)
+}
+
+// UpdateName updates the name of a device.
+func (d *DevicesService) UpdateName(deviceID string, name string) (*DeviceDetail, error) {
+	updateRequest := DeviceUpdateRequest{
+		Name: name,
+	}
+	return d.Update(deviceID, updateRequest)
+}
+
+// UpdateDescription updates the description of a device.
+func (d *DevicesService) UpdateDescription(deviceID string, description string) (*DeviceDetail, error) {
+	updateRequest := DeviceUpdateRequest{
+		Description: description,
+	}
+	return d.Update(deviceID, updateRequest)
+}
+
+// UpdateTags updates the tags of a device.
+func (d *DevicesService) UpdateTags(deviceID string, tags []string) (*DeviceDetail, error) {
+	updateRequest := DeviceUpdateRequest{
+		Tags: tags,
+	}
+	return d.Update(deviceID, updateRequest)
+}

--- a/cloudconnexa/devices_test.go
+++ b/cloudconnexa/devices_test.go
@@ -1,0 +1,295 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// createTestClient creates a test client with the given server
+func createTestClient(server *httptest.Server) *Client {
+	client := &Client{
+		client:      server.Client(),
+		BaseURL:     server.URL,
+		Token:       "test-token",
+		RateLimiter: rate.NewLimiter(rate.Every(1*time.Second), 5),
+	}
+	client.Devices = (*DevicesService)(&service{client: client})
+	client.Sessions = (*SessionsService)(&service{client: client})
+	client.NetworkConnectors = (*NetworkConnectorsService)(&service{client: client})
+	return client
+}
+
+func TestDevicesService_List(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/devices" {
+			t.Errorf("Expected path /api/v1/devices, got %s", r.URL.Path)
+		}
+
+		// Mock response
+		response := DevicePageResponse{
+			Content: []DeviceDetail{
+				{
+					ID:     "device-1",
+					Name:   "Test Device 1",
+					UserID: "user-1",
+					Status: "ACTIVE",
+				},
+				{
+					ID:     "device-2",
+					Name:   "Test Device 2",
+					UserID: "user-2",
+					Status: "INACTIVE",
+				},
+			},
+			NumberOfElements: 2,
+			Page:             0,
+			Size:             10,
+			Success:          true,
+			TotalElements:    2,
+			TotalPages:       1,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestClient(server)
+
+	// Test the List method
+	options := DeviceListOptions{
+		Page: 0,
+		Size: 10,
+	}
+	result, err := client.Devices.List(options)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(result.Content) != 2 {
+		t.Errorf("Expected 2 devices, got %d", len(result.Content))
+	}
+
+	if result.Content[0].ID != "device-1" {
+		t.Errorf("Expected device ID 'device-1', got %s", result.Content[0].ID)
+	}
+
+	if result.TotalElements != 2 {
+		t.Errorf("Expected total elements 2, got %d", result.TotalElements)
+	}
+}
+
+func TestDevicesService_GetByID(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/devices/device-123" {
+			t.Errorf("Expected path /api/v1/devices/device-123, got %s", r.URL.Path)
+		}
+
+		// Mock response
+		device := DeviceDetail{
+			ID:        "device-123",
+			Name:      "Test Device",
+			UserID:    "user-123",
+			Status:    "ACTIVE",
+			Type:      "CLIENT",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(device)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestClient(server)
+
+	// Test the GetByID method
+	result, err := client.Devices.GetByID("device-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if result.ID != "device-123" {
+		t.Errorf("Expected device ID 'device-123', got %s", result.ID)
+	}
+
+	if result.Name != "Test Device" {
+		t.Errorf("Expected device name 'Test Device', got %s", result.Name)
+	}
+
+	if result.Status != "ACTIVE" {
+		t.Errorf("Expected device status 'ACTIVE', got %s", result.Status)
+	}
+}
+
+func TestDevicesService_Update(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/devices/device-123" {
+			t.Errorf("Expected path /api/v1/devices/device-123, got %s", r.URL.Path)
+		}
+
+		// Mock response
+		device := DeviceDetail{
+			ID:          "device-123",
+			Name:        "Updated Device Name",
+			Description: "Updated description",
+			UserID:      "user-123",
+			Status:      "ACTIVE",
+			Type:        "CLIENT",
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(device)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestClient(server)
+
+	// Test the Update method
+	updateRequest := DeviceUpdateRequest{
+		Name:        "Updated Device Name",
+		Description: "Updated description",
+	}
+	result, err := client.Devices.Update("device-123", updateRequest)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if result.Name != "Updated Device Name" {
+		t.Errorf("Expected device name 'Updated Device Name', got %s", result.Name)
+	}
+
+	if result.Description != "Updated description" {
+		t.Errorf("Expected device description 'Updated description', got %s", result.Description)
+	}
+}
+
+func TestDevicesService_Block(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mock response
+		device := DeviceDetail{
+			ID:     "device-123",
+			Name:   "Test Device",
+			UserID: "user-123",
+			Status: "BLOCKED",
+			Type:   "CLIENT",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(device)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestClient(server)
+
+	// Test the Block method
+	result, err := client.Devices.Block("device-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if result.Status != "BLOCKED" {
+		t.Errorf("Expected device status 'BLOCKED', got %s", result.Status)
+	}
+}
+
+func TestDevicesService_ListByUserID(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("userId") != "user-123" {
+			t.Errorf("Expected userId=user-123, got %s", query.Get("userId"))
+		}
+
+		// Mock response
+		response := DevicePageResponse{
+			Content: []DeviceDetail{
+				{
+					ID:     "device-1",
+					Name:   "User Device 1",
+					UserID: "user-123",
+					Status: "ACTIVE",
+				},
+				{
+					ID:     "device-2",
+					Name:   "User Device 2",
+					UserID: "user-123",
+					Status: "INACTIVE",
+				},
+			},
+			NumberOfElements: 2,
+			Page:             0,
+			Size:             100,
+			Success:          true,
+			TotalElements:    2,
+			TotalPages:       1,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestClient(server)
+
+	// Test the ListByUserID method
+	result, err := client.Devices.ListByUserID("user-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 devices, got %d", len(result))
+	}
+
+	for _, device := range result {
+		if device.UserID != "user-123" {
+			t.Errorf("Expected device userID 'user-123', got %s", device.UserID)
+		}
+	}
+}
+
+func TestDevicesService_List_InvalidSize(t *testing.T) {
+	client := &Client{
+		RateLimiter: rate.NewLimiter(rate.Every(1*time.Second), 5),
+	}
+	client.Devices = (*DevicesService)(&service{client: client})
+
+	// Test with size too large
+	options := DeviceListOptions{
+		Size: 1001,
+	}
+	_, err := client.Devices.List(options)
+	if err == nil {
+		t.Error("Expected error for size 1001, got nil")
+	}
+}

--- a/cloudconnexa/network_connectors.go
+++ b/cloudconnexa/network_connectors.go
@@ -223,3 +223,61 @@ func (c *NetworkConnectorsService) Delete(connectorID string, networkID string) 
 	_, err = c.client.DoRequest(req)
 	return err
 }
+
+// IPsecStartResponse represents the response from starting an IPsec tunnel.
+type IPsecStartResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status,omitempty"`
+}
+
+// IPsecStopResponse represents the response from stopping an IPsec tunnel.
+type IPsecStopResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status,omitempty"`
+}
+
+// StartIPsec starts an IPsec tunnel for the specified network connector.
+func (c *NetworkConnectorsService) StartIPsec(connectorID string) (*IPsecStartResponse, error) {
+	endpoint := fmt.Sprintf("%s/networks/connectors/%s/ipsec/start", c.client.GetV1Url(), connectorID)
+	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response IPsecStartResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// StopIPsec stops an IPsec tunnel for the specified network connector.
+func (c *NetworkConnectorsService) StopIPsec(connectorID string) (*IPsecStopResponse, error) {
+	endpoint := fmt.Sprintf("%s/networks/connectors/%s/ipsec/stop", c.client.GetV1Url(), connectorID)
+	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response IPsecStopResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/cloudconnexa/network_connectors_ipsec_test.go
+++ b/cloudconnexa/network_connectors_ipsec_test.go
@@ -1,0 +1,149 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// createTestIPsecClient creates a test client with the given server for IPsec testing
+func createTestIPsecClient(server *httptest.Server) *Client {
+	client := &Client{
+		client:      server.Client(),
+		BaseURL:     server.URL,
+		Token:       "test-token",
+		RateLimiter: rate.NewLimiter(rate.Every(1*time.Second), 5),
+	}
+	client.NetworkConnectors = (*NetworkConnectorsService)(&service{client: client})
+	return client
+}
+
+func TestNetworkConnectorsService_StartIPsec(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/networks/connectors/connector-123/ipsec/start" {
+			t.Errorf("Expected path /api/v1/networks/connectors/connector-123/ipsec/start, got %s", r.URL.Path)
+		}
+
+		// Mock response
+		response := IPsecStartResponse{
+			Success: true,
+			Message: "IPsec tunnel started successfully",
+			Status:  "STARTING",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestIPsecClient(server)
+
+	// Test the StartIPsec method
+	result, err := client.NetworkConnectors.StartIPsec("connector-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success to be true")
+	}
+
+	if result.Message != "IPsec tunnel started successfully" {
+		t.Errorf("Expected message 'IPsec tunnel started successfully', got %s", result.Message)
+	}
+
+	if result.Status != "STARTING" {
+		t.Errorf("Expected status 'STARTING', got %s", result.Status)
+	}
+}
+
+func TestNetworkConnectorsService_StopIPsec(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/networks/connectors/connector-123/ipsec/stop" {
+			t.Errorf("Expected path /api/v1/networks/connectors/connector-123/ipsec/stop, got %s", r.URL.Path)
+		}
+
+		// Mock response
+		response := IPsecStopResponse{
+			Success: true,
+			Message: "IPsec tunnel stopped successfully",
+			Status:  "STOPPED",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestIPsecClient(server)
+
+	// Test the StopIPsec method
+	result, err := client.NetworkConnectors.StopIPsec("connector-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success to be true")
+	}
+
+	if result.Message != "IPsec tunnel stopped successfully" {
+		t.Errorf("Expected message 'IPsec tunnel stopped successfully', got %s", result.Message)
+	}
+
+	if result.Status != "STOPPED" {
+		t.Errorf("Expected status 'STOPPED', got %s", result.Status)
+	}
+}
+
+func TestNetworkConnectorsService_StartIPsec_Error(t *testing.T) {
+	// Create a mock server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Connector not found"}`))
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestIPsecClient(server)
+
+	// Test the StartIPsec method with error
+	_, err := client.NetworkConnectors.StartIPsec("invalid-connector")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestNetworkConnectorsService_StopIPsec_Error(t *testing.T) {
+	// Create a mock server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Connector not found"}`))
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestIPsecClient(server)
+
+	// Test the StopIPsec method with error
+	_, err := client.NetworkConnectors.StopIPsec("invalid-connector")
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}

--- a/cloudconnexa/sessions.go
+++ b/cloudconnexa/sessions.go
@@ -1,0 +1,182 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// SessionStatus represents the possible statuses of an OpenVPN session.
+type SessionStatus string
+
+const (
+	// SessionStatusActive represents an active session.
+	SessionStatusActive SessionStatus = "ACTIVE"
+	// SessionStatusCompleted represents a completed session.
+	SessionStatusCompleted SessionStatus = "COMPLETED"
+	// SessionStatusFailed represents a failed session.
+	SessionStatusFailed SessionStatus = "FAILED"
+)
+
+// Session represents an OpenVPN session in CloudConnexa.
+type Session struct {
+	ID               string     `json:"id"`
+	UserID           string     `json:"userId"`
+	DeviceID         string     `json:"deviceId"`
+	Status           string     `json:"status"`
+	StartTime        time.Time  `json:"startTime"`
+	EndTime          *time.Time `json:"endTime,omitempty"`
+	Duration         *int64     `json:"duration,omitempty"`
+	BytesReceived    int64      `json:"bytesReceived"`
+	BytesSent        int64      `json:"bytesSent"`
+	ClientIP         string     `json:"clientIp"`
+	ServerIP         string     `json:"serverIp"`
+	Protocol         string     `json:"protocol"`
+	Port             int        `json:"port"`
+	Region           string     `json:"region"`
+	Gateway          string     `json:"gateway"`
+	DisconnectReason string     `json:"disconnectReason,omitempty"`
+	ClientVersion    string     `json:"clientVersion,omitempty"`
+	ClientOS         string     `json:"clientOs,omitempty"`
+	ClientOSVersion  string     `json:"clientOsVersion,omitempty"`
+	TunnelIPv4       string     `json:"tunnelIpv4,omitempty"`
+	TunnelIPv6       string     `json:"tunnelIpv6,omitempty"`
+	PublicIP         string     `json:"publicIp,omitempty"`
+	CreatedAt        time.Time  `json:"createdAt"`
+	UpdatedAt        time.Time  `json:"updatedAt"`
+}
+
+// SessionsResponse represents the response from the sessions API endpoint.
+type SessionsResponse struct {
+	Sessions   []Session `json:"sessions"`
+	NextCursor string    `json:"nextCursor,omitempty"`
+}
+
+// SessionsListOptions represents the options for listing sessions.
+type SessionsListOptions struct {
+	StartDate     *time.Time    `json:"startDate,omitempty"`
+	EndDate       *time.Time    `json:"endDate,omitempty"`
+	Status        SessionStatus `json:"status,omitempty"`
+	ReturnOnlyNew bool          `json:"returnOnlyNew,omitempty"`
+	Size          int           `json:"size"`
+	Cursor        string        `json:"cursor,omitempty"`
+}
+
+// SessionsService provides methods for managing OpenVPN sessions.
+type SessionsService service
+
+// List retrieves a list of OpenVPN sessions with optional filtering.
+// The size parameter is required and must be between 1 and 100.
+// Returns a SessionsResponse containing sessions and optional next cursor for pagination.
+func (s *SessionsService) List(options SessionsListOptions) (*SessionsResponse, error) {
+	// Validate size parameter
+	if options.Size < 1 || options.Size > 100 {
+		return nil, fmt.Errorf("size must be between 1 and 100, got %d", options.Size)
+	}
+
+	// Build query parameters
+	params := url.Values{}
+	params.Set("size", strconv.Itoa(options.Size))
+
+	if options.StartDate != nil {
+		params.Set("startDate", options.StartDate.Format(time.RFC3339))
+	}
+
+	if options.EndDate != nil {
+		params.Set("endDate", options.EndDate.Format(time.RFC3339))
+	}
+
+	if options.Status != "" {
+		params.Set("status", string(options.Status))
+	}
+
+	if options.ReturnOnlyNew {
+		params.Set("returnOnlyNew", "true")
+	}
+
+	if options.Cursor != "" {
+		params.Set("cursor", options.Cursor)
+	}
+
+	endpoint := fmt.Sprintf("%s/sessions?%s", s.client.GetV1Url(), params.Encode())
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := s.client.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SessionsResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// ListAll retrieves all sessions by automatically handling pagination.
+// This method will make multiple API calls if necessary to retrieve all sessions.
+// Use with caution as it may result in many API calls for large datasets.
+func (s *SessionsService) ListAll(options SessionsListOptions) ([]Session, error) {
+	var allSessions []Session
+	cursor := options.Cursor
+
+	// Set a reasonable default size if not specified
+	if options.Size == 0 {
+		options.Size = 100
+	}
+
+	for {
+		options.Cursor = cursor
+		response, err := s.List(options)
+		if err != nil {
+			return nil, err
+		}
+
+		allSessions = append(allSessions, response.Sessions...)
+
+		// If there's no next cursor, we've retrieved all sessions
+		if response.NextCursor == "" {
+			break
+		}
+
+		cursor = response.NextCursor
+	}
+
+	return allSessions, nil
+}
+
+// ListActive retrieves all active sessions.
+func (s *SessionsService) ListActive(size int) (*SessionsResponse, error) {
+	options := SessionsListOptions{
+		Status: SessionStatusActive,
+		Size:   size,
+	}
+	return s.List(options)
+}
+
+// ListByDateRange retrieves sessions within a specific date range.
+func (s *SessionsService) ListByDateRange(startDate, endDate time.Time, size int) (*SessionsResponse, error) {
+	options := SessionsListOptions{
+		StartDate: &startDate,
+		EndDate:   &endDate,
+		Size:      size,
+	}
+	return s.List(options)
+}
+
+// ListByStatus retrieves sessions with a specific status.
+func (s *SessionsService) ListByStatus(status SessionStatus, size int) (*SessionsResponse, error) {
+	options := SessionsListOptions{
+		Status: status,
+		Size:   size,
+	}
+	return s.List(options)
+}

--- a/cloudconnexa/sessions_test.go
+++ b/cloudconnexa/sessions_test.go
@@ -1,0 +1,198 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// createTestSessionsClient creates a test client with the given server for sessions testing
+func createTestSessionsClient(server *httptest.Server) *Client {
+	client := &Client{
+		client:      server.Client(),
+		BaseURL:     server.URL,
+		Token:       "test-token",
+		RateLimiter: rate.NewLimiter(rate.Every(1*time.Second), 5),
+	}
+	client.Sessions = (*SessionsService)(&service{client: client})
+	return client
+}
+
+func TestSessionsService_List(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the request method and path
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/sessions" {
+			t.Errorf("Expected path /api/v1/sessions, got %s", r.URL.Path)
+		}
+
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("size") != "10" {
+			t.Errorf("Expected size=10, got %s", query.Get("size"))
+		}
+
+		// Mock response
+		response := SessionsResponse{
+			Sessions: []Session{
+				{
+					ID:     "session-1",
+					UserID: "user-1",
+					Status: "ACTIVE",
+				},
+				{
+					ID:     "session-2",
+					UserID: "user-2",
+					Status: "COMPLETED",
+				},
+			},
+			NextCursor: "next-cursor-123",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestSessionsClient(server)
+
+	// Test the List method
+	options := SessionsListOptions{
+		Size: 10,
+	}
+	result, err := client.Sessions.List(options)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(result.Sessions) != 2 {
+		t.Errorf("Expected 2 sessions, got %d", len(result.Sessions))
+	}
+
+	if result.Sessions[0].ID != "session-1" {
+		t.Errorf("Expected session ID 'session-1', got %s", result.Sessions[0].ID)
+	}
+
+	if result.NextCursor != "next-cursor-123" {
+		t.Errorf("Expected next cursor 'next-cursor-123', got %s", result.NextCursor)
+	}
+}
+
+func TestSessionsService_ListActive(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("status") != "ACTIVE" {
+			t.Errorf("Expected status=ACTIVE, got %s", query.Get("status"))
+		}
+
+		// Mock response
+		response := SessionsResponse{
+			Sessions: []Session{
+				{
+					ID:     "session-1",
+					UserID: "user-1",
+					Status: "ACTIVE",
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestSessionsClient(server)
+
+	// Test the ListActive method
+	result, err := client.Sessions.ListActive(10)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(result.Sessions) != 1 {
+		t.Errorf("Expected 1 session, got %d", len(result.Sessions))
+	}
+
+	if result.Sessions[0].Status != "ACTIVE" {
+		t.Errorf("Expected session status 'ACTIVE', got %s", result.Sessions[0].Status)
+	}
+}
+
+func TestSessionsService_ListByDateRange(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("startDate") == "" {
+			t.Error("Expected startDate parameter")
+		}
+		if query.Get("endDate") == "" {
+			t.Error("Expected endDate parameter")
+		}
+
+		// Mock response
+		response := SessionsResponse{
+			Sessions: []Session{
+				{
+					ID:        "session-1",
+					UserID:    "user-1",
+					Status:    "COMPLETED",
+					StartTime: time.Now(),
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with mock server
+	client := createTestSessionsClient(server)
+
+	// Test the ListByDateRange method
+	startDate := time.Now().AddDate(0, 0, -7) // 7 days ago
+	endDate := time.Now()
+	result, err := client.Sessions.ListByDateRange(startDate, endDate, 10)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(result.Sessions) != 1 {
+		t.Errorf("Expected 1 session, got %d", len(result.Sessions))
+	}
+}
+
+func TestSessionsService_List_InvalidSize(t *testing.T) {
+	client := &Client{
+		RateLimiter: rate.NewLimiter(rate.Every(1*time.Second), 5),
+	}
+	client.Sessions = (*SessionsService)(&service{client: client})
+
+	// Test with size too small
+	options := SessionsListOptions{
+		Size: 0,
+	}
+	_, err := client.Sessions.List(options)
+	if err == nil {
+		t.Error("Expected error for size 0, got nil")
+	}
+
+	// Test with size too large
+	options.Size = 101
+	_, err = client.Sessions.List(options)
+	if err == nil {
+		t.Error("Expected error for size 101, got nil")
+	}
+}


### PR DESCRIPTION
This PR implements three missing API endpoints from CloudConnexa API [v1.1.0](https://openvpn.net/cloud-docs/developer/cloudconnexa-api-v1-1-0.html):
- **Sessions API** - Complete OpenVPN sessions management
- **Devices API** - Full device lifecycle management
- **IPsec** for **Network Connectors** - Start/stop IPsec tunnels