### PR TITLE
Implement base URL validation

### DIFF
--- a/cloudconnexa/errors.go
+++ b/cloudconnexa/errors.go
@@ -10,3 +10,9 @@ var ErrEmptyID = errors.New("id cannot be empty")
 
 // ErrResponseTooLarge is returned when a response body exceeds the configured size limit.
 var ErrResponseTooLarge = errors.New("response body exceeds maximum allowed size")
+
+// ErrInvalidBaseURL is returned when the base URL is malformed or cannot be parsed.
+var ErrInvalidBaseURL = errors.New("invalid base URL")
+
+// ErrHTTPSRequired is returned when HTTP is used but HTTPS is required for security.
+var ErrHTTPSRequired = errors.New("HTTPS required: HTTP is not allowed for OAuth credentials")

--- a/cloudconnexa/vpn_regions_test.go
+++ b/cloudconnexa/vpn_regions_test.go
@@ -42,7 +42,9 @@ func TestVPNRegionsService_List(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(server.URL, "test", "test")
+	client, err := NewClientWithOptions(server.URL, "test", "test", &ClientOptions{
+		AllowInsecureHTTP: true,
+	})
 	assert.NoError(t, err)
 	regions, err := client.VPNRegions.List()
 
@@ -73,7 +75,9 @@ func TestVPNRegionsService_GetByID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(server.URL, "test", "test")
+	client, err := NewClientWithOptions(server.URL, "test", "test", &ClientOptions{
+		AllowInsecureHTTP: true,
+	})
 	assert.NoError(t, err)
 
 	// Test existing region


### PR DESCRIPTION
## Description

User-supplied IDs are directly interpolated into URL paths without encoding, creating a path traversal vulnerability. This fix applies `url.PathEscape()` to all path segments and standardises query parameter construction using `url.Values{}`.