### PR TITLE
Add v1.2.2 DTO fields: GatewaysIDs and AccessGroup.DefaultGroup

### DIFF
--- a/cloudconnexa/access_groups.go
+++ b/cloudconnexa/access_groups.go
@@ -14,11 +14,12 @@ import (
 // AccessGroup represents a group of access rules that define network access permissions.
 // It contains source and destination rules that determine what resources can access each other.
 type AccessGroup struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Description string       `json:"description,omitempty"`
-	Source      []AccessItem `json:"source"`
-	Destination []AccessItem `json:"destination"`
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	Description  string       `json:"description,omitempty"`
+	Source       []AccessItem `json:"source"`
+	Destination  []AccessItem `json:"destination"`
+	DefaultGroup string       `json:"defaultGroup,omitempty"`
 }
 
 // AccessItem represents a single access rule item that can be either a source or destination.

--- a/cloudconnexa/access_groups_dto_test.go
+++ b/cloudconnexa/access_groups_dto_test.go
@@ -1,0 +1,36 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAccessGroup_DefaultGroupRoundTrip(t *testing.T) {
+	original := AccessGroup{
+		ID:           "ag-1",
+		Name:         "AG 1",
+		DefaultGroup: "default",
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded AccessGroup
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.DefaultGroup != original.DefaultGroup {
+		t.Errorf("DefaultGroup round-trip mismatch.\nWant: %q\nGot:  %q", original.DefaultGroup, decoded.DefaultGroup)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["defaultGroup"]; !ok {
+		t.Error("Expected JSON key \"defaultGroup\" to be present")
+	}
+}

--- a/cloudconnexa/hosts.go
+++ b/cloudconnexa/hosts.go
@@ -17,6 +17,7 @@ type Host struct {
 	InternetAccess string          `json:"internetAccess"`
 	SystemSubnets  []string        `json:"systemSubnets"`
 	Connectors     []HostConnector `json:"connectors"`
+	GatewaysIDs    []string        `json:"gatewaysIds,omitempty"`
 }
 
 // HostPageResponse represents a paginated response of hosts.

--- a/cloudconnexa/hosts_dto_test.go
+++ b/cloudconnexa/hosts_dto_test.go
@@ -1,0 +1,37 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestHost_GatewaysIDsRoundTrip(t *testing.T) {
+	original := Host{
+		ID:          "host-1",
+		Name:        "Host 1",
+		GatewaysIDs: []string{"gw-1", "gw-2"},
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded Host
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(decoded.GatewaysIDs, original.GatewaysIDs) {
+		t.Errorf("GatewaysIDs round-trip mismatch.\nWant: %v\nGot:  %v", original.GatewaysIDs, decoded.GatewaysIDs)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["gatewaysIds"]; !ok {
+		t.Error("Expected JSON key \"gatewaysIds\" to be present")
+	}
+}

--- a/cloudconnexa/networks.go
+++ b/cloudconnexa/networks.go
@@ -28,6 +28,7 @@ type Network struct {
 	Connectors        []NetworkConnector `json:"connectors"`
 	Routes            []Route            `json:"routes"`
 	TunnelingProtocol string             `json:"tunnelingProtocol"`
+	GatewaysIDs       []string           `json:"gatewaysIds,omitempty"`
 }
 
 // NetworkPageResponse represents a paginated response of networks.

--- a/cloudconnexa/networks_dto_test.go
+++ b/cloudconnexa/networks_dto_test.go
@@ -1,0 +1,37 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestNetwork_GatewaysIDsRoundTrip(t *testing.T) {
+	original := Network{
+		ID:          "network-1",
+		Name:        "Network 1",
+		GatewaysIDs: []string{"gw-1", "gw-2"},
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded Network
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(decoded.GatewaysIDs, original.GatewaysIDs) {
+		t.Errorf("GatewaysIDs round-trip mismatch.\nWant: %v\nGot:  %v", original.GatewaysIDs, decoded.GatewaysIDs)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["gatewaysIds"]; !ok {
+		t.Error("Expected JSON key \"gatewaysIds\" to be present")
+	}
+}


### PR DESCRIPTION
Closes the schema-coverage gap on three response types:
- Network.GatewaysIDs       (json: gatewaysIds)
- Host.GatewaysIDs          (json: gatewaysIds)
- AccessGroup.DefaultGroup  (json: defaultGroup)

All three are tagged omitempty so existing serialization is unchanged when the fields are unset. Round-trip tests live in *_dto_test.go files alongside the modified types.
