### PR TITLE
Split network application route DTOs and add ExactMatch

### DIFF
--- a/cloudconnexa/host_applications.go
+++ b/cloudconnexa/host_applications.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 )
 
-// ApplicationRoute represents a route configuration for an application.
+// ApplicationRoute represents a route configuration for a host application.
+// Mirrors the API HostApplicationRouteRequest schema.
 type ApplicationRoute struct {
 	Value           string `json:"value"`
 	AllowEmbeddedIP bool   `json:"allowEmbeddedIp"`

--- a/cloudconnexa/network_applications.go
+++ b/cloudconnexa/network_applications.go
@@ -8,33 +8,86 @@ import (
 	"net/http"
 )
 
+// NetworkApplicationRoute represents a route configuration for a network application.
+// Mirrors the API NetworkApplicationRouteRequest schema. ExactMatch is supported
+// only for network application routes; the host application equivalent
+// (ApplicationRoute) does not include it.
+type NetworkApplicationRoute struct {
+	Value           string `json:"value"`
+	AllowEmbeddedIP bool   `json:"allowEmbeddedIp"`
+	ExactMatch      bool   `json:"exactMatch,omitempty"`
+}
+
+// NetworkApplicationDomainRoute represents a domain route returned by the network
+// application endpoints. Mirrors the API NetworkDomainRouteResponse schema, which
+// — unlike HostDomainRouteResponse — carries the ExactMatch flag.
+type NetworkApplicationDomainRoute struct {
+	ID              string `json:"id,omitempty"`
+	Type            string `json:"type,omitempty"`
+	Domain          string `json:"domain,omitempty"`
+	AllowEmbeddedIP bool   `json:"allowEmbeddedIp,omitempty"`
+	ExactMatch      bool   `json:"exactMatch,omitempty"`
+}
+
+// NetworkApplication represents a network application request body.
+// It is structurally similar to Application but uses NetworkApplicationRoute
+// for its routes so that ExactMatch is honored.
+type NetworkApplication struct {
+	Name            string                     `json:"name"`
+	Description     string                     `json:"description"`
+	NetworkItemType string                     `json:"networkItemType"`
+	NetworkItemID   string                     `json:"networkItemId"`
+	ID              string                     `json:"id"`
+	Routes          []*NetworkApplicationRoute `json:"routes"`
+	Config          *ApplicationConfig         `json:"config"`
+}
+
+// NetworkApplicationResponse represents the response payload for network application
+// operations. Routes carry the network-specific NetworkApplicationDomainRoute,
+// which exposes ExactMatch.
+type NetworkApplicationResponse struct {
+	NetworkApplication
+	Routes []*NetworkApplicationDomainRoute `json:"routes"`
+}
+
+// NetworkApplicationPageResponse represents a paginated response of network applications.
+type NetworkApplicationPageResponse struct {
+	Content          []NetworkApplicationResponse `json:"content"`
+	NumberOfElements int                          `json:"numberOfElements"`
+	Page             int                          `json:"page"`
+	Size             int                          `json:"size"`
+	Success          bool                         `json:"success"`
+	TotalElements    int                          `json:"totalElements"`
+	TotalPages       int                          `json:"totalPages"`
+}
+
 // NetworkApplicationsService provides methods for managing network applications.
 type NetworkApplicationsService service
 
 // GetApplicationsByPage retrieves network applications using pagination.
-func (c *NetworkApplicationsService) GetApplicationsByPage(page int, pageSize int) (ApplicationPageResponse, error) {
+func (c *NetworkApplicationsService) GetApplicationsByPage(page int, pageSize int) (NetworkApplicationPageResponse, error) {
 	endpoint := fmt.Sprintf("%s/networks/applications?page=%d&size=%d", c.client.GetV1Url(), page, pageSize)
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
-		return ApplicationPageResponse{}, err
+		return NetworkApplicationPageResponse{}, err
 	}
 
 	body, err := c.client.DoRequest(req)
 	if err != nil {
-		return ApplicationPageResponse{}, err
+		return NetworkApplicationPageResponse{}, err
 	}
 
-	var response ApplicationPageResponse
+	var response NetworkApplicationPageResponse
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return ApplicationPageResponse{}, err
+		return NetworkApplicationPageResponse{}, err
 	}
 	return response, nil
 }
 
 // List retrieves all network applications by paginating through all available pages.
-func (c *NetworkApplicationsService) List() ([]ApplicationResponse, error) {
-	var allApplications []ApplicationResponse
+func (c *NetworkApplicationsService) List() ([]NetworkApplicationResponse, error) {
+	var allApplications []NetworkApplicationResponse
 	page := 0
 
 	for {
@@ -54,7 +107,7 @@ func (c *NetworkApplicationsService) List() ([]ApplicationResponse, error) {
 }
 
 // Get retrieves a specific network application by its ID.
-func (c *NetworkApplicationsService) Get(id string) (*ApplicationResponse, error) {
+func (c *NetworkApplicationsService) Get(id string) (*NetworkApplicationResponse, error) {
 	if err := validateID(id); err != nil {
 		return nil, err
 	}
@@ -69,7 +122,7 @@ func (c *NetworkApplicationsService) Get(id string) (*ApplicationResponse, error
 		return nil, err
 	}
 
-	var application ApplicationResponse
+	var application NetworkApplicationResponse
 	err = json.Unmarshal(body, &application)
 	if err != nil {
 		return nil, err
@@ -80,13 +133,13 @@ func (c *NetworkApplicationsService) Get(id string) (*ApplicationResponse, error
 // GetByName retrieves a network application by its name
 // name: The name of the network application to retrieve
 // Returns the network application and any error that occurred
-func (c *NetworkApplicationsService) GetByName(name string) (*ApplicationResponse, error) {
+func (c *NetworkApplicationsService) GetByName(name string) (*NetworkApplicationResponse, error) {
 	items, err := c.List()
 	if err != nil {
 		return nil, err
 	}
 
-	filtered := make([]ApplicationResponse, 0)
+	filtered := make([]NetworkApplicationResponse, 0)
 	for _, item := range items {
 		if item.Name == name {
 			filtered = append(filtered, item)
@@ -102,7 +155,7 @@ func (c *NetworkApplicationsService) GetByName(name string) (*ApplicationRespons
 }
 
 // Create creates a new network application.
-func (c *NetworkApplicationsService) Create(application *Application) (*ApplicationResponse, error) {
+func (c *NetworkApplicationsService) Create(application *NetworkApplication) (*NetworkApplicationResponse, error) {
 	applicationJSON, err := json.Marshal(application)
 	if err != nil {
 		return nil, err
@@ -120,7 +173,7 @@ func (c *NetworkApplicationsService) Create(application *Application) (*Applicat
 		return nil, err
 	}
 
-	var s ApplicationResponse
+	var s NetworkApplicationResponse
 	err = json.Unmarshal(body, &s)
 	if err != nil {
 		return nil, err
@@ -129,7 +182,7 @@ func (c *NetworkApplicationsService) Create(application *Application) (*Applicat
 }
 
 // Update updates an existing network application by its ID.
-func (c *NetworkApplicationsService) Update(id string, application *Application) (*ApplicationResponse, error) {
+func (c *NetworkApplicationsService) Update(id string, application *NetworkApplication) (*NetworkApplicationResponse, error) {
 	if err := validateID(id); err != nil {
 		return nil, err
 	}
@@ -150,7 +203,7 @@ func (c *NetworkApplicationsService) Update(id string, application *Application)
 		return nil, err
 	}
 
-	var s ApplicationResponse
+	var s NetworkApplicationResponse
 	err = json.Unmarshal(body, &s)
 	if err != nil {
 		return nil, err

--- a/cloudconnexa/network_applications_dto_test.go
+++ b/cloudconnexa/network_applications_dto_test.go
@@ -1,0 +1,99 @@
+package cloudconnexa
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNetworkApplicationRoute_ExactMatchRoundTrip(t *testing.T) {
+	original := NetworkApplicationRoute{
+		Value:           "example.com",
+		AllowEmbeddedIP: true,
+		ExactMatch:      true,
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded NetworkApplicationRoute
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded != original {
+		t.Errorf("Round-trip mismatch.\nWant: %+v\nGot:  %+v", original, decoded)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["exactMatch"]; !ok {
+		t.Error("Expected JSON key \"exactMatch\" to be present when set true")
+	}
+}
+
+func TestNetworkApplicationRoute_ExactMatchOmittedWhenFalse(t *testing.T) {
+	encoded, err := json.Marshal(NetworkApplicationRoute{
+		Value:           "example.com",
+		AllowEmbeddedIP: false,
+		ExactMatch:      false,
+	})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["exactMatch"]; ok {
+		t.Errorf("Expected JSON key \"exactMatch\" to be omitted when false; got: %s", encoded)
+	}
+}
+
+func TestApplicationRoute_NoExactMatch(t *testing.T) {
+	// Host application routes must not carry exactMatch — the schema does
+	// not define it for HostApplicationRouteRequest.
+	encoded, err := json.Marshal(ApplicationRoute{
+		Value:           "example.com",
+		AllowEmbeddedIP: true,
+	})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["exactMatch"]; ok {
+		t.Errorf("Host ApplicationRoute should not include \"exactMatch\"; got: %s", encoded)
+	}
+}
+
+func TestNetworkApplicationDomainRoute_RoundTrip(t *testing.T) {
+	original := NetworkApplicationDomainRoute{
+		ID:              "route-1",
+		Type:            "DOMAIN",
+		Domain:          "example.com",
+		AllowEmbeddedIP: true,
+		ExactMatch:      true,
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded NetworkApplicationDomainRoute
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded != original {
+		t.Errorf("Round-trip mismatch.\nWant: %+v\nGot:  %+v", original, decoded)
+	}
+}


### PR DESCRIPTION
The CloudConnexa schema differs between host and network application route types: NetworkApplicationRouteRequest and NetworkDomainRouteResponse carry an exactMatch flag that the host equivalents do not. Previously both services shared Application / ApplicationRoute / ApplicationResponse, which left no place to express the network-only field.

This change:
- Adds NetworkApplicationRoute (request DTO with ExactMatch).
- Adds NetworkApplicationDomainRoute (response DTO with ExactMatch).
- Adds NetworkApplication / NetworkApplicationResponse / NetworkApplicationPageResponse to keep the network type graph isolated.
- Rewires NetworkApplicationsService methods to use the new types.
- Updates the ApplicationRoute doc comment in host_applications.go to state that it is the host variant; HostApplicationsService is otherwise untouched.

Round-trip tests verify that ExactMatch round-trips on the network DTO, that omitempty keeps it out when unset, and that the host DTO never emits the field.

BREAKING CHANGE: NetworkApplicationsService.Create / Update / GetApplicationsByPage / List / Get / GetByName now take and return the new NetworkApplication* types instead of the shared Application*.